### PR TITLE
Add usage segment with ccusage-style display

### DIFF
--- a/src/lib/segment-renderer.ts
+++ b/src/lib/segment-renderer.ts
@@ -145,6 +145,23 @@ export class SegmentRenderer {
     };
   }
 
+  renderUsage(usageInfo: UsageInfo, colors: any): SegmentData | null {
+    if (!usageInfo || !usageInfo.daily) return null;
+
+    const { percentage, used, total } = usageInfo.daily;
+    
+    if (percentage === null || used === null || total === null) return null;
+
+    const text = `${percentage.toFixed(1)}% (${this.formatTokensForUsage(used)}/${this.formatTokensForUsage(total)})`;
+    const usageColors = this.getUsageColors(percentage, colors);
+
+    return {
+      text,
+      bgColor: usageColors.bg,
+      fgColor: usageColors.fg,
+    };
+  }
+
   renderTmux(sessionId: string | null, colors: any): SegmentData | null {
     if (!sessionId) return null;
 
@@ -246,6 +263,26 @@ export class SegmentRenderer {
       }
 
       return result;
+    }
+  }
+
+  private formatTokensForUsage(tokens: number): string {
+    if (tokens >= 1_000_000) {
+      return `${(tokens / 1_000_000).toFixed(1)}M`;
+    } else if (tokens >= 1_000) {
+      return `${(tokens / 1_000).toFixed(1)}k`;
+    }
+    return tokens.toString();
+  }
+
+  private getUsageColors(percentage: number, colors: any): { bg: string; fg: string } {
+    // Match ccusage thresholds: Green 0-80%, Yellow 80-100%, Red >100%
+    if (percentage > 100) {
+      return { bg: colors.usageBg, fg: '#ef4444' }; // Red text
+    } else if (percentage >= 80) {
+      return { bg: colors.usageBg, fg: '#eab308' }; // Yellow text
+    } else {
+      return { bg: colors.usageBg, fg: '#16a34a' }; // Green text
     }
   }
 }

--- a/src/powerline.ts
+++ b/src/powerline.ts
@@ -131,6 +131,9 @@ export class PowerlineRenderer {
           blockType
         );
 
+      case "usage":
+        return this.segmentRenderer.renderUsage(usageInfo, colors);
+
       case "tmux":
         const tmuxSessionId = this.tmuxService.getSessionId();
         return this.segmentRenderer.renderTmux(tmuxSessionId, colors);
@@ -178,6 +181,8 @@ export class PowerlineRenderer {
       todayFg: hexToAnsi(colorTheme.today.fg, false),
       blockBg: hexToAnsi(colorTheme.block.bg, true),
       blockFg: hexToAnsi(colorTheme.block.fg, false),
+      usageBg: hexToAnsi(colorTheme.usage.bg, true),
+      usageFg: hexToAnsi(colorTheme.usage.fg, false),
       burnLowBg: hexToAnsi(colorTheme.today.bg, true),
       burnFg: hexToAnsi(colorTheme.today.fg, false),
       tmuxBg: hexToAnsi(colorTheme.tmux.bg, true),
@@ -202,6 +207,8 @@ export class PowerlineRenderer {
         return colors.burnLowBg;
       case "block":
         return colors.blockBg;
+      case "usage":
+        return colors.usageBg;
       case "tmux":
         return colors.tmuxBg;
       default:

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -28,6 +28,7 @@ export interface ColorTheme {
   session: SegmentColor;
   today: SegmentColor;
   block: SegmentColor;
+  usage: SegmentColor;
   tmux: SegmentColor;
 }
 
@@ -39,6 +40,7 @@ export interface LineConfig {
     session?: UsageSegmentConfig;
     today?: UsageSegmentConfig;
     block?: BlockSegmentConfig;
+    usage?: SegmentConfig;
     tmux?: TmuxSegmentConfig;
   };
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -27,6 +27,8 @@ export interface PowerlineColors {
   todayFg: string;
   blockBg: string;
   blockFg: string;
+  usageBg: string;
+  usageFg: string;
   burnLowBg: string;
   burnFg: string;
   tmuxBg: string;


### PR DESCRIPTION
## Summary
- Add new usage segment that displays daily token usage in ccusage-style format
- Shows percentage and token breakdown: "20.7% (3.8M/18.5M)"
- Dynamic color coding matching ccusage thresholds (Green 0-80%, Yellow 80-100%, Red >100%)

## Test plan
- Enable usage segment in powerline configuration
- Verify percentage calculation and token formatting  
- Test color changes across different usage thresholds
- Confirm integration with existing powerline segments

## Changes
- Added usage segment configuration to type interfaces
- Implemented renderUsage method with ccusage-compatible formatting
- Added token formatting helpers (M/k suffixes)
- Integrated usage segment into powerline rendering pipeline